### PR TITLE
Add app.yaml

### DIFF
--- a/_pages/Scheduling/Scheduling.md
+++ b/_pages/Scheduling/Scheduling.md
@@ -4,7 +4,3 @@ title: Scheduling
 parent: "/iCalendar-Topics"
 order: 6
 ---
-
-# Scheduling
-
-TBD

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,27 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+application: calconnect-devguide
+version: 1
+
+
+handlers:
+- url: /(.+)/
+  static_files: _site/\1/index.html
+  upload: _site/(.+)/index.html
+
+# site root
+- url: /
+  static_files: _site/index.html
+  upload: _site/index.html
+
+# For folders without trailing slashes - ideally a 301 redirect, but we're static & it isn't 2004
+- url: /([^\.]+)([^/])
+  static_files: _site/\1\2/index.html
+  upload: _site/(.+)
+
+# Redirect Everything else
+- url: /(.+)
+  static_files: _site/\1
+  upload: _site/(.+)
+

--- a/app.yaml
+++ b/app.yaml
@@ -3,7 +3,7 @@ api_version: 1
 threadsafe: true
 application: calconnect-devguide
 version: 1
-
+default_expiration: "1m"
 
 handlers:
 - url: /(.+)/


### PR DESCRIPTION
App.yaml is required to host this on an App Engine instance. The configuration basically tells App Engine to serve everything in the `_site` directory.